### PR TITLE
Add configVersion check in JSON response validation

### DIFF
--- a/src/otaVersionChecker.ts
+++ b/src/otaVersionChecker.ts
@@ -125,7 +125,7 @@ export async function checkOTAVersion(
   // Check if response is JSON
   if (contentType && contentType.includes('application/json')) {
     const jsonData = await response.json();
-    if (!jsonData || typeof jsonData !== 'object' || !jsonData.version) {
+    if (!jsonData || typeof jsonData !== 'object' || !jsonData.version  || !jsonData.configVersion) {
       throw new Error('Invalid JSON response: missing version field');
     }
     versionConfig = jsonData as OTAVersionConfig;


### PR DESCRIPTION
Jumbaro reported that this check is failing in internal Dark's fork of Nitro OTA :).

I have fixed there and it works fine . So I moving this fix to open source version so that internal and this is sync