### PR TITLE
fix: export config plugin as CommonJS function

### DIFF
--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,1 +1,1 @@
-module.exports = require('./expo/plugins/dist/index.js');
+module.exports = require('./expo/plugins/dist/index.js').default;


### PR DESCRIPTION
app.plugin.js was exporting { default: fn } instead of fn directly, causing Expo to reject it
  with 'does not contain a valid config plugin'